### PR TITLE
Update good first issue workflow to work for multiple labels

### DIFF
--- a/.github/workflows/projectboard.yml
+++ b/.github/workflows/projectboard.yml
@@ -1,0 +1,31 @@
+name: issue-to-project-board-workflow
+on:
+  # Trigger when an issue gets labeled or deleted
+  issues:
+    types: [reopened, closed, labeled, unlabeled, assigned, unassigned]
+
+jobs:
+  setup_matrix_input:
+    runs-on: ubuntu-latest
+
+    steps:
+      - id: set-matrix 
+        run: |
+          output=$(curl ${{ github.event.issue.url }}/labels | jq '.[] | .name')
+
+          echo '======================'
+          echo 'Process incoming data'
+          echo '======================'
+          json=$(echo $output | sed 's/"\s"/","/g')
+          echo $json
+          echo "::set-output name=matrix::$(echo $json)"
+    outputs:
+      issueTags: ${{ steps.set-matrix.outputs.matrix }}
+      
+  Manage_project_issues:
+    needs: setup_matrix_input
+    uses: vapor/ci/.github/workflows/issues-to-project-board.yml@main
+    with:
+      labelsJson: ${{ needs.setup_matrix_input.outputs.issueTags }}
+    secrets: 
+      PROJECT_BOARD_AUTOMATION_PAT: "${{ secrets.PROJECT_BOARD_AUTOMATION_PAT }}"


### PR DESCRIPTION
This pr updates the project board workflow to use the reusable workflow defined in the [Vapor CI repository](https://github.com/vapor/ci).